### PR TITLE
Using overwritten request path if it exists in res.locals from middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This is a prefix for Kevin's internal API. You probably don't need to change thi
 -   Type: `Function`
 -   Default: `path => path`
 
-Given a request path, return the name of the asset we're trying to serve. Useful if you have entries that don't map to the filenames they render.
+Given a request path, req object, and res object, return the name of the asset we're trying to serve. Useful if you have entries that don't map to the filenames they render.
 
 #### `additionalOverlayInfo`
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This is a prefix for Kevin's internal API. You probably don't need to change thi
 #### `getAssetName`
 
 -   Type: `Function`
--   Default: `path => path`
+-   Default: `(requestPath, req, res) => requestPath.replace(/^\//, "").replace(/\.js$/, "")`
 
 Given a request path, req object, and res object, return the name of the asset we're trying to serve. Useful if you have entries that don't map to the filenames they render.
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -282,7 +282,7 @@ class Kevin {
         res.setHeader("X-Kevin-Middleware-Version", PLUGIN_VERSION);
         res.statusCode = 200;
         const compiler = manager.getWebpackCompiler(configName);
-        const reqPath = req.path;
+        const reqPath = res.locals.overwrittenReqPath || req.path;
         const assetPath = getPathToServe(compiler, reqPath);
         const content = fs.readFileSync(assetPath);
         res.setHeader("Content-Length", content.length);
@@ -320,7 +320,7 @@ class Kevin {
         // a function.
         const middleware = function kevinMiddleware(req, res, next) {
             // This is the name of the asset requested
-            const reqPath = req.path;
+            const reqPath = res.locals.overwrittenReqPath || req.path;
 
             // ========================================
             // Is it one of our internal API endpoints?

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -348,7 +348,7 @@ class Kevin {
             }
 
             // Mangle the url to get asset name
-            const assetName = this.getAssetName(reqPath);
+            const assetName = this.getAssetName(reqPath, req, res);
             // Select appropriate config for given asset
             const config = this.getConfigForAssetName(assetName, this.configs);
             // Bail if none are found (this path may be handled by another middleware)

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -42,11 +42,11 @@ class Kevin {
             // Set to 0 to never evict anything, but that'll probably make you run out of
             // memory.
             maxCompilers = 3,
-            // Given a request path, return the name of the asset we're trying to serve.
+            // Given a request path, the req object, and the res object, return the name of the asset we're trying to serve.
             // Useful if you have entries that don't map to the filenames they render.
             // Default: strip off leading forward slash and js extension. This is because
             // the middleware will store things as `app-a/a1`, but requests will be for `/app-a/a1.js`.
-            getAssetName = (requestPath) =>
+            getAssetName = (requestPath, req, res) =>
                 requestPath.replace(/^\//, "").replace(/\.js$/, ""),
             // Only build assets; don't handle serving them. This is useful if you want to do
             // something with the built asset before serving it.
@@ -282,7 +282,7 @@ class Kevin {
         res.setHeader("X-Kevin-Middleware-Version", PLUGIN_VERSION);
         res.statusCode = 200;
         const compiler = manager.getWebpackCompiler(configName);
-        const reqPath = res.locals.overwrittenReqPath || req.path;
+        const reqPath = req.path;
         const assetPath = getPathToServe(compiler, reqPath);
         const content = fs.readFileSync(assetPath);
         res.setHeader("Content-Length", content.length);
@@ -320,7 +320,7 @@ class Kevin {
         // a function.
         const middleware = function kevinMiddleware(req, res, next) {
             // This is the name of the asset requested
-            const reqPath = res.locals.overwrittenReqPath || req.path;
+            const reqPath = req.path;
 
             // ========================================
             // Is it one of our internal API endpoints?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kevin-middleware",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "This is an Express middleware that makes developing javascript in a monorepo easier.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
In one use case for Etsyweb, we will rewrite the request path in a middleware. This updates Kevin to use the overwritten request path if it exists in `res.locals`. 