### PR TITLE
Add an endpoint to restart a compiler by name

### DIFF
--- a/lib/CompilerManager.js
+++ b/lib/CompilerManager.js
@@ -11,7 +11,7 @@ const { logError } = require("./logger");
 
 class CompilerManager {
     /**
-     * @param {bool} $0.useFrequency - if true, use frequency instead of frecency
+     * @param {boolean} $0.useFrequency - if true, use frequency instead of frecency
      *      to determine compiler eviction.
      */
     constructor({ useFrequency = false } = {}) {
@@ -38,7 +38,7 @@ class CompilerManager {
 
     /**
      * @param {string} name - compiler's name
-     * @returns {bool}
+     * @returns {boolean}
      */
     isCompilerActive(name) {
         return !!this.activeCompilers[name];
@@ -214,16 +214,18 @@ class CompilerManager {
      * Calls invalidate on the compiler's Watching instance, without
      * stopping the watch process.
      * @param {string} name compiler's name
+     * @return {boolean} true if we found a compiler and invalidated it, false otherwise.
      */
     invalidateCompiler(name) {
         if (!this.isCompilerActive(name)) {
             logError(
                 `Tried to invalidate compiler ${name}, but it's not being managed`
             );
-            return;
+            return false;
         }
         const compiler = this.activeCompilers[name];
         compiler.invalidate();
+        return true;
     }
 
     /**

--- a/lib/ManagedCompiler.js
+++ b/lib/ManagedCompiler.js
@@ -5,7 +5,7 @@
 
 // These are the states that a compiler can be in.
 const { PLUGIN_NAME, FIRST_BUILD, BUILDING, ERROR, DONE } = require("./constants");
-const { logError } = require("./logger");
+const { logError, logInfo } = require("./logger");
 
 // This is the number of minutes to consider when determining
 // frequency. If the range is 10, frequency is calculated as the

--- a/lib/ManagedCompiler.js
+++ b/lib/ManagedCompiler.js
@@ -5,7 +5,7 @@
 
 // These are the states that a compiler can be in.
 const { PLUGIN_NAME, FIRST_BUILD, BUILDING, ERROR, DONE } = require("./constants");
-const { logError, logInfo } = require("./logger");
+const { logError } = require("./logger");
 
 // This is the number of minutes to consider when determining
 // frequency. If the range is 10, frequency is calculated as the

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -324,6 +324,7 @@ class Kevin {
 
             // ========================================
             // Is it one of our internal API endpoints?
+            // TODO: This should probably use a Router
             // ========================================
             if (reqPath === `${this.kevinApiPrefix}/build-status`) {
                 // this endpoint shows the state of each compiler. the overlay
@@ -345,6 +346,42 @@ class Kevin {
                 // which kevin is being run
                 res.json(manager.getHumanReadableMemoryUsage());
                 return;
+            }
+
+            if (req.method === "POST" && reqPath === `${this.kevinApiPrefix}/restart-compiler`) {
+                // This endpoint restarts compilers. It accepts two query params:
+                // `compiler` (required), which is the name of the compiler, and
+                // `hard` (optional) which, if true, fully shuts down and restarts the compiler,
+                //          rather than just invalidating it and forcing a partial recompilation.
+                if (!req.query.compiler || !manager.isCompilerActive(req.query.compiler)) {
+                    return res.status(400).send("Kevin couldn't find a compiler with that name");
+                }
+                // If hard is set to anything that looks like "true", let's force restart the compiler.
+                if (req.query.hard && req.query.hard.toLowerCase() === "true") {
+                    manager.closeCompiler(req.query.compiler)
+                        .then((name) => {
+                            if (!name) {
+                                res.status(400).send("Kevin couldn't find a compiler with that name");
+                            }
+                            return this.buildConfig(name);
+                        })
+                        .then(() => res.sendStatus(200))
+                        .catch((err) => {
+                            logError(err);
+                            res.status(500).send(`Something went wrong trying to restart ${req.query.compiler}. Check the logs for details.`)
+                        });
+
+                    return;
+                }
+                else if (manager.invalidateCompiler(req.query.compiler)) {
+                    logInfo(`Soft-restarted compiler: ${req.query.compiler}`);
+                    res.sendStatus(200);
+                    return;
+                } else {
+                    logInfo(`Could not restart this compiler (does it exist?): ${req.query.compiler}`);
+                    res.status(400).send("Kevin couldn't find a compiler with that name");
+                    return;
+                }
             }
 
             // Mangle the url to get asset name

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -116,7 +116,9 @@ class Kevin {
     buildConfig(configName) {
         const config = this.configs.find((config) => config.name === configName);
         if (!config) {
-            logError(`Trying to build config: ${configName}, but it can't be found.`);
+            const msg = `Trying to build config: ${configName}, but it can't be found.`;
+            logError(msg);
+            return Promise.reject(msg);
         }
 
         // determine if there's a compiler already
@@ -348,38 +350,59 @@ class Kevin {
                 return;
             }
 
-            if (req.method === "POST" && reqPath === `${this.kevinApiPrefix}/restart-compiler`) {
+            if (
+                req.method === "POST" &&
+                reqPath === `${this.kevinApiPrefix}/restart-compiler`
+            ) {
                 // This endpoint restarts compilers. It accepts two query params:
                 // `compiler` (required), which is the name of the compiler, and
                 // `hard` (optional) which, if true, fully shuts down and restarts the compiler,
                 //          rather than just invalidating it and forcing a partial recompilation.
-                if (!req.query.compiler || !manager.isCompilerActive(req.query.compiler)) {
-                    return res.status(400).send("Kevin couldn't find a compiler with that name");
+                if (
+                    !req.query.compiler ||
+                    !manager.isCompilerActive(req.query.compiler)
+                ) {
+                    return res
+                        .status(400)
+                        .send(
+                            `Kevin couldn't find a compiler named ${req.query.compiler}.`
+                        );
                 }
                 // If hard is set to anything that looks like "true", let's force restart the compiler.
                 if (req.query.hard && req.query.hard.toLowerCase() === "true") {
-                    manager.closeCompiler(req.query.compiler)
+                    manager
+                        .closeCompiler(req.query.compiler)
                         .then((name) => {
                             if (!name) {
-                                res.status(400).send("Kevin couldn't find a compiler with that name");
+                                return res
+                                    .status(400)
+                                    .send(
+                                        `Kevin couldn't find a compiler named ${req.query.compiler}.`
+                                    );
                             }
-                            return this.buildConfig(name);
+                            return this.buildConfig(name).then(() =>
+                                res.sendStatus(200)
+                            );
                         })
-                        .then(() => res.sendStatus(200))
                         .catch((err) => {
                             logError(err);
-                            res.status(500).send(`Something went wrong trying to restart ${req.query.compiler}. Check the logs for details.`)
+                            res.status(500).send(
+                                `Something went wrong trying to restart ${req.query.compiler}. Check the logs for details.`
+                            );
                         });
 
                     return;
-                }
-                else if (manager.invalidateCompiler(req.query.compiler)) {
+                } else if (manager.invalidateCompiler(req.query.compiler)) {
                     logInfo(`Soft-restarted compiler: ${req.query.compiler}`);
                     res.sendStatus(200);
                     return;
                 } else {
-                    logInfo(`Could not restart this compiler (does it exist?): ${req.query.compiler}`);
-                    res.status(400).send("Kevin couldn't find a compiler with that name");
+                    logInfo(
+                        `Could not restart this compiler (does it exist?): ${req.query.compiler}`
+                    );
+                    res.status(400).send(
+                        "Kevin couldn't find a compiler with that name"
+                    );
                     return;
                 }
             }


### PR DESCRIPTION
This endpoint has a 'soft' and a 'hard' restart. The former kicks off what is effectively a partial recompilation by invalidating the state of the compiler. It's pretty fast, but isn't good at things like busting caches. A 'hard' restart literally closes and restarts the compiler, showing the overlay and all that.

This isn't all that fancy yet, and I'd want to add a "stop" and "start" endpoint at some point (and maybe a UI?), but this'll at least let us unstick a compiler with a bad cache.