### PR TITLE
allowing kevin to map entrypoints to multiple configs

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -48,15 +48,20 @@ class Kevin {
             // the middleware will store things as `app-a/a1`, but requests will be for `/app-a/a1.js`.
             getAssetName = (requestPath, req, res) =>
                 requestPath.replace(/^\//, "").replace(/\.js$/, ""),
-            // Only build assets; don't handle serving them. This is useful if you want to do
-            // something with the built asset before serving it.
-            selectConfigNameGivenReqPath = (reqPath, configNames) => {
+            // Given a request path and a set of configNames, return the name of the config
+            // we're interested in using to handle this request
+            selectConfigName = (reqPath, configNames) => {
                 if (!configNames) {
                     return null;
+                }
+                if (configNames.length > 1) {
+                    logError("Multiple configNames found, using first one.");
                 }
 
                 return configNames[0];
             },
+            // Only build assets; don't handle serving them. This is useful if you want to do
+            // something with the built asset before serving it.
             buildOnly = false,
             // Root path for Kevin's API to be exposed through. This is used to tell the
             // loading modal where to look for data on the status of builds. This should be
@@ -85,7 +90,7 @@ class Kevin {
         this.maxCompilers = maxCompilers;
         this.getAssetName = getAssetName;
         this.buildOnly = buildOnly;
-        this.selectConfigNameGivenReqPath = selectConfigNameGivenReqPath;
+        this.selectConfigName = selectConfigName;
         this.kevinPublicPath = kevinPublicPath;
         this.kevinApiPrefix = kevinApiPrefix;
         this.additionalOverlayInfo = additionalOverlayInfo;
@@ -104,7 +109,7 @@ class Kevin {
      */
     getConfigForAssetName(reqPath, assetName, configs) {
         const configNames = this.entryMap[assetName];
-        const configName = this.selectConfigNameGivenReqPath(reqPath, configNames);
+        const configName = this.selectConfigName(reqPath, configNames);
         if (!configName) {
             return null;
         }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -55,7 +55,11 @@ class Kevin {
                     return null;
                 }
                 if (configNames.length > 1) {
-                    logError("Multiple configNames found, using first one.");
+                    logError(
+                        `Multiple configNames found for ${reqPath}: ${configNames.join(
+                            ","
+                        )}. Using first one.`
+                    );
                 }
 
                 return configNames[0];

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -50,6 +50,13 @@ class Kevin {
                 requestPath.replace(/^\//, "").replace(/\.js$/, ""),
             // Only build assets; don't handle serving them. This is useful if you want to do
             // something with the built asset before serving it.
+            selectConfigNameGivenReqPath = (reqPath, configNames) => {
+                if (!configNames) {
+                    return null;
+                }
+
+                return configNames[0];
+            },
             buildOnly = false,
             // Root path for Kevin's API to be exposed through. This is used to tell the
             // loading modal where to look for data on the status of builds. This should be
@@ -78,6 +85,7 @@ class Kevin {
         this.maxCompilers = maxCompilers;
         this.getAssetName = getAssetName;
         this.buildOnly = buildOnly;
+        this.selectConfigNameGivenReqPath = selectConfigNameGivenReqPath;
         this.kevinPublicPath = kevinPublicPath;
         this.kevinApiPrefix = kevinApiPrefix;
         this.additionalOverlayInfo = additionalOverlayInfo;
@@ -94,8 +102,9 @@ class Kevin {
      * @param {array} configs — array of webpack config objects
      * @returns {string|null} - the name of the config, or null if there is none
      */
-    getConfigForAssetName(assetName, configs) {
-        const configName = this.entryMap[assetName];
+    getConfigForAssetName(reqPath, assetName, configs) {
+        const configNames = this.entryMap[assetName];
+        const configName = this.selectConfigNameGivenReqPath(reqPath, configNames);
         if (!configName) {
             return null;
         }
@@ -410,7 +419,7 @@ class Kevin {
             // Mangle the url to get asset name
             const assetName = this.getAssetName(reqPath, req, res);
             // Select appropriate config for given asset
-            const config = this.getConfigForAssetName(assetName, this.configs);
+            const config = this.getConfigForAssetName(reqPath, assetName, this.configs);
             // Bail if none are found (this path may be handled by another middleware)
             if (!config) {
                 // TODO: It may be a chunk file!! Make sure we either serve static

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,8 +105,10 @@ const validateConfigs = function (configs) {
 /**
  * Given an array of webpack configs (i.e. a multicompiler config), generate a mapping
  * from entrypoints to the name of the config responsible for it.
- * Throw an excption if we find two configs that handle the same asset.
- * That may be extreme, but if it is we can fix it when it becomes a problem.
+ *
+ * This used to throw an exception if multiple configs were capable of handling the same
+ * entrypoint. Now it will return a list of possible configs, and it is up to whoever is
+ * utilizing this map to correctly extract the correct config name.
  * @param {array} configs
  */
 const initializeEntryMap = function (configs) {
@@ -130,12 +132,10 @@ const initializeEntryMap = function (configs) {
         } else {
             Object.keys(entry).forEach((key) => {
                 if (entryMap[key]) {
-                    throw new Error(
-                        `Entrypoint ${key} is built by both ${entryMap[key]} ` +
-                            `and ${configName}. Only one config should handle an entry.`
-                    );
+                    entryMap[key].push(configName);
+                } else {
+                    entryMap[key] = [configName];
                 }
-                entryMap[key] = configName;
             });
         }
     });

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -88,3 +88,30 @@ describe("kevin's validateConfigs utility", () => {
         }).toThrowError(/your configs share a name/);
     });
 });
+describe("initializeEntryMap", () => {
+    const { initializeEntryMap } = require("../../lib/utils");
+
+    it("returns a list of names of all configs able to handle entrypoint", () => {
+        const configs = [
+            {
+                name: "someConfigEntry",
+                entry: {
+                    someEntryPoint: `./someEntryPoint`,
+                },
+            },
+            {
+                name: "someOtherConfigEntry",
+                entry: {
+                    someEntryPoint: `./someEntryPoint`,
+                },
+            },
+        ];
+
+        const entryMap = initializeEntryMap(configs);
+
+        expect(entryMap.someEntryPoint).toEqual([
+            "someConfigEntry",
+            "someOtherConfigEntry",
+        ]);
+    });
+});


### PR DESCRIPTION
This allows kevin to map entrypoints to multiple configs. It allows for users to specify their selection criteria for a configName based on the request URI. Please see https://github.com/etsy/buildapack/pull/162 as these two PRs are marching somewhat in lockstep