### PR TITLE
Modify /compiler-info to show both active and inactive compilers

### DIFF
--- a/lib/CompilerManager.js
+++ b/lib/CompilerManager.js
@@ -147,7 +147,7 @@ class CompilerManager {
      */
     getAllCompilerInfo() {
         const result = { compilers: {}, leastUsedCompiler: null };
-        Object.entries(this.activeCompilers).forEach(([name, _compiler]) => {
+        Object.keys(this.activeCompilers).forEach((name) => {
             result.compilers[name] = this.getInfoForCompiler(name);
         });
         result.leastUsedCompiler = this.getLeastUsedCompiler();

--- a/lib/CompilerManager.js
+++ b/lib/CompilerManager.js
@@ -143,30 +143,13 @@ class CompilerManager {
 
     /**
      * Get more complete compiler info on all compilers for debugging purposes
-     * @param {String[]} configNames list of all compilers (active and inactive)
      * @return {Object} a map of data keyed on compiler names
      */
-    getAllCompilerInfo(configNames) {
-        // Copy the compilers list to a new array
-        let compilersList = Array.from(configNames);
+    getAllCompilerInfo() {
         const result = { compilers: {}, leastUsedCompiler: null };
-        Object.entries(this.activeCompilers).forEach(([name, compiler]) => {
+        Object.entries(this.activeCompilers).forEach(([name, _compiler]) => {
             result.compilers[name] = this.getInfoForCompiler(name);
-
-            // Remove the active compiler from the compilers list
-            compilersList = compilersList.filter(
-                (compilerName) => compilerName !== name
-            );
         });
-
-        // Add the inactive compilers and their "not-built" status
-        // to the result
-        compilersList.forEach((name) => {
-            result.compilers[name] = {
-                status: "not-built",
-            };
-        });
-
         result.leastUsedCompiler = this.getLeastUsedCompiler();
         return result;
     }

--- a/lib/CompilerManager.js
+++ b/lib/CompilerManager.js
@@ -143,13 +143,30 @@ class CompilerManager {
 
     /**
      * Get more complete compiler info on all compilers for debugging purposes
+     * @param {Array} configNames list of all compilers (active and inactive)
      * @return {Object} a map of data keyed on compiler names
      */
-    getAllCompilerInfo() {
+    getAllCompilerInfo(configNames) {
+        // Copy the compilers list to a new array
+        let compilersList = Array.from(configNames);
         const result = { compilers: {}, leastUsedCompiler: null };
         Object.entries(this.activeCompilers).forEach(([name, compiler]) => {
             result.compilers[name] = this.getInfoForCompiler(name);
+
+            // Remove the active compiler from the compilers list
+            compilersList = compilersList.filter(
+                (compilerName) => compilerName !== name
+            );
         });
+
+        // Add the inactive compilers and their "not-built" status
+        // to the result
+        compilersList.forEach((name) => {
+            result.compilers[name] = {
+                status: "not-built",
+            };
+        });
+
         result.leastUsedCompiler = this.getLeastUsedCompiler();
         return result;
     }

--- a/lib/CompilerManager.js
+++ b/lib/CompilerManager.js
@@ -143,7 +143,7 @@ class CompilerManager {
 
     /**
      * Get more complete compiler info on all compilers for debugging purposes
-     * @param {Array} configNames list of all compilers (active and inactive)
+     * @param {String[]} configNames list of all compilers (active and inactive)
      * @return {Object} a map of data keyed on compiler names
      */
     getAllCompilerInfo(configNames) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,6 +6,7 @@ const FIRST_BUILD = "first-build";
 const BUILDING = "building";
 const ERROR = "error";
 const DONE = "done";
+const NOT_BUILT = "not-built";
 
 module.exports = {
     PLUGIN_NAME,
@@ -14,4 +15,5 @@ module.exports = {
     BUILDING,
     ERROR,
     DONE,
+    NOT_BUILT,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,7 +6,6 @@ const FIRST_BUILD = "first-build";
 const BUILDING = "building";
 const ERROR = "error";
 const DONE = "done";
-const NOT_BUILT = "not-built";
 
 module.exports = {
     PLUGIN_NAME,
@@ -15,5 +14,4 @@ module.exports = {
     BUILDING,
     ERROR,
     DONE,
-    NOT_BUILT,
 };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -101,7 +101,7 @@ class Kevin {
 
         this.entryMap = initializeEntryMap(this.configs);
 
-        // Save all the config names
+        // Save all the config names -- all compilers list
         this.configNames = this.configs.map((config) => config.name);
     }
 
@@ -360,7 +360,9 @@ class Kevin {
                 // this endpoint shows general details about each compiler,
                 // particularly metrics around its use and whether it may
                 // be eligible for eviction
-                res.json(manager.getAllCompilerInfo());
+                // 2022 note: adding config names so this endpoint
+                // also shows the inactive compilers
+                res.json(manager.getAllCompilerInfo(this.configNames));
                 return;
             }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -362,7 +362,7 @@ class Kevin {
                 // be eligible for eviction
                 // 2022 note: adding config names so this endpoint
                 // also shows the inactive compilers
-                res.json(manager.getAllCompilerInfo(this.configNames));
+                res.json(manager.getAllCompilerInfo());
                 return;
             }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -100,6 +100,9 @@ class Kevin {
         this.additionalOverlayInfo = additionalOverlayInfo;
 
         this.entryMap = initializeEntryMap(this.configs);
+
+        // Save all the config names
+        this.configNames = this.configs.map((config) => config.name);
     }
 
     /**

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -29,6 +29,7 @@ const {
     FIRST_BUILD,
     ERROR,
     DONE,
+    NOT_BUILT,
 } = require("./constants");
 
 // we're leaving manager detached from Kevin to keep it and its methods private
@@ -100,9 +101,6 @@ class Kevin {
         this.additionalOverlayInfo = additionalOverlayInfo;
 
         this.entryMap = initializeEntryMap(this.configs);
-
-        // Save all the config names -- all compilers list
-        this.configNames = this.configs.map((config) => config.name);
     }
 
     /**
@@ -362,7 +360,15 @@ class Kevin {
                 // be eligible for eviction
                 // 2022 note: adding config names so this endpoint
                 // also shows the inactive compilers
-                res.json(manager.getAllCompilerInfo());
+                const { compilers, leastUsedCompiler } = manager.getAllCompilerInfo();
+                this.configs.forEach(({ name }) => {
+                    if (Object.prototype.hasOwnProperty.call(compilers, name)) {
+                        return;
+                    }
+                    compilers[name] = { status: NOT_BUILT };
+                });
+
+                res.json({ compilers, leastUsedCompiler });
                 return;
             }
 

--- a/test/lib/CompilerManager.test.js
+++ b/test/lib/CompilerManager.test.js
@@ -1,7 +1,13 @@
 "use strict";
 
 const CompilerManager = require("../../lib/CompilerManager");
-const { FIRST_BUILD, BUILDING, ERROR, DONE } = require("../../lib/constants");
+const {
+    FIRST_BUILD,
+    BUILDING,
+    ERROR,
+    DONE,
+    NOT_BUILT,
+} = require("../../lib/constants");
 
 beforeAll(() => {
     jest.spyOn(global.console, "error").mockImplementation(() => {});
@@ -94,7 +100,7 @@ describe("getStatus", () => {
 });
 
 describe("getAllBuildStatuses", () => {
-    it("should show the build states of all compilers", () => {
+    it("should show the build states of active compilers", () => {
         const manager = new CompilerManager();
         manager.manageCompiler("nick", getMockCompiler(), {});
         manager.manageCompiler("elback", getMockCompiler(), {}, BUILDING);
@@ -116,5 +122,46 @@ describe("getAllBuildStatuses", () => {
             isnt: DONE,
             good: DONE,
         });
+    });
+});
+
+describe("getAllCompilerInfo", () => {
+    it("should return an object with both active and inactive compilers", () => {
+        const manager = new CompilerManager();
+        // Active compilers
+        manager.manageCompiler("iam", getMockCompiler(), {});
+        manager.manageCompiler("an", getMockCompiler(), {}, BUILDING);
+        manager.manageCompiler("active", getMockCompiler(), {}, DONE);
+        manager.manageCompiler("region", getMockCompiler(), {}, ERROR);
+
+        // All compilers
+        const configNames = ["foo", "bar", "lala", "iam", "an", "active", "region"];
+        expect(manager.getAllCompilerInfo(configNames)).toEqual(
+            expect.objectContaining({
+                compilers: {
+                    iam: expect.objectContaining({
+                        status: FIRST_BUILD,
+                    }),
+                    an: expect.objectContaining({
+                        status: BUILDING,
+                    }),
+                    active: expect.objectContaining({
+                        status: DONE,
+                    }),
+                    region: expect.objectContaining({
+                        status: ERROR,
+                    }),
+                    foo: expect.objectContaining({
+                        status: NOT_BUILT,
+                    }),
+                    bar: expect.objectContaining({
+                        status: NOT_BUILT,
+                    }),
+                    lala: expect.objectContaining({
+                        status: NOT_BUILT,
+                    }),
+                },
+            })
+        );
     });
 });

--- a/test/lib/CompilerManager.test.js
+++ b/test/lib/CompilerManager.test.js
@@ -151,17 +151,58 @@ describe("getAllCompilerInfo", () => {
                     region: expect.objectContaining({
                         status: ERROR,
                     }),
-                    foo: expect.objectContaining({
+                    // Inactive compilers should not have any other info
+                    foo: {
                         status: NOT_BUILT,
-                    }),
-                    bar: expect.objectContaining({
+                    },
+                    bar: {
                         status: NOT_BUILT,
-                    }),
-                    lala: expect.objectContaining({
+                    },
+                    lala: {
                         status: NOT_BUILT,
-                    }),
+                    },
                 },
             })
         );
+    });
+
+    it("should return more information about the active compilers", () => {
+        const manager = new CompilerManager();
+        // Active compilers
+        manager.manageCompiler("iam", getMockCompiler(), {});
+        manager.manageCompiler("an", getMockCompiler(), {}, BUILDING);
+        manager.manageCompiler("active", getMockCompiler(), {}, DONE);
+        manager.manageCompiler("region", getMockCompiler(), {}, ERROR);
+
+        const configNames = ["foo", "bar", "lala", "iam", "an", "active", "region"];
+        const moreInfo = {
+            errors: expect.any(Array),
+            frequency: expect.any(Number),
+            frecency: expect.any(Number),
+            frequencyChecks: expect.any(Array),
+            pinned: expect.any(Boolean),
+        };
+
+        expect(manager.getAllCompilerInfo(configNames)).toEqual({
+            compilers: expect.objectContaining({
+                iam: {
+                    status: FIRST_BUILD,
+                    ...moreInfo,
+                },
+                an: {
+                    status: BUILDING,
+                    ...moreInfo,
+                },
+                active: {
+                    status: DONE,
+                    ...moreInfo,
+                },
+                region: {
+                    status: ERROR,
+                    ...moreInfo,
+                },
+            }),
+            leastUsedCompiler: expect.any(String),
+        });
     });
 });

--- a/test/lib/CompilerManager.test.js
+++ b/test/lib/CompilerManager.test.js
@@ -1,13 +1,7 @@
 "use strict";
 
 const CompilerManager = require("../../lib/CompilerManager");
-const {
-    FIRST_BUILD,
-    BUILDING,
-    ERROR,
-    DONE,
-    NOT_BUILT,
-} = require("../../lib/constants");
+const { FIRST_BUILD, BUILDING, ERROR, DONE } = require("../../lib/constants");
 
 beforeAll(() => {
     jest.spyOn(global.console, "error").mockImplementation(() => {});
@@ -126,7 +120,7 @@ describe("getAllBuildStatuses", () => {
 });
 
 describe("getAllCompilerInfo", () => {
-    it("should return an object with both active and inactive compilers", () => {
+    it("should return an object with active compilers", () => {
         const manager = new CompilerManager();
         // Active compilers
         manager.manageCompiler("iam", getMockCompiler(), {});
@@ -134,9 +128,7 @@ describe("getAllCompilerInfo", () => {
         manager.manageCompiler("active", getMockCompiler(), {}, DONE);
         manager.manageCompiler("region", getMockCompiler(), {}, ERROR);
 
-        // All compilers
-        const configNames = ["foo", "bar", "lala", "iam", "an", "active", "region"];
-        expect(manager.getAllCompilerInfo(configNames)).toEqual(
+        expect(manager.getAllCompilerInfo()).toEqual(
             expect.objectContaining({
                 compilers: {
                     iam: expect.objectContaining({
@@ -151,16 +143,6 @@ describe("getAllCompilerInfo", () => {
                     region: expect.objectContaining({
                         status: ERROR,
                     }),
-                    // Inactive compilers should not have any other info
-                    foo: {
-                        status: NOT_BUILT,
-                    },
-                    bar: {
-                        status: NOT_BUILT,
-                    },
-                    lala: {
-                        status: NOT_BUILT,
-                    },
                 },
             })
         );
@@ -168,13 +150,12 @@ describe("getAllCompilerInfo", () => {
 
     it("should return more information about the active compilers", () => {
         const manager = new CompilerManager();
-        // Active compilers
+
         manager.manageCompiler("iam", getMockCompiler(), {});
         manager.manageCompiler("an", getMockCompiler(), {}, BUILDING);
         manager.manageCompiler("active", getMockCompiler(), {}, DONE);
         manager.manageCompiler("region", getMockCompiler(), {}, ERROR);
 
-        const configNames = ["foo", "bar", "lala", "iam", "an", "active", "region"];
         const moreInfo = {
             errors: expect.any(Array),
             frequency: expect.any(Number),
@@ -183,7 +164,7 @@ describe("getAllCompilerInfo", () => {
             pinned: expect.any(Boolean),
         };
 
-        expect(manager.getAllCompilerInfo(configNames)).toEqual({
+        expect(manager.getAllCompilerInfo()).toEqual({
             compilers: expect.objectContaining({
                 iam: {
                     status: FIRST_BUILD,


### PR DESCRIPTION
### Why make this change?

We need an endpoint that returns all the compilers, both active and inactive. Before this change, endpoints only show active compilers.

### What is the change?

It adds the inactive compilers and their `not built` status to the compilers list returned by the `/compiler-info` endpoint.

### Testing

Run `yarn test` and make sure all tests pass. 

### Questions and additional information for Reviewer
First time contributing to Kevin 👀 
