### PR TITLE
Add a start and stop compiler endpoints

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -463,7 +463,7 @@ class Kevin {
                                     `Kevin couldn't find a compiler named ${req.query.compiler}.`
                                 );
                         }
-                        logInfo(`Stopped compiler: ${req.query.compiler}`);
+                        logNotice(`Stopped compiler: ${req.query.compiler}`);
                         return res.sendStatus(200);
                     })
                     .catch((err) => {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -436,6 +436,46 @@ class Kevin {
                 }
             }
 
+            if (
+                req.method === "POST" &&
+                reqPath === `${this.kevinApiPrefix}/stop-compiler`
+            ) {
+                // This endpoints stops a compiler. It accepts one query param:
+                // `compiler` (required), the name of the compiler to be stopped
+                if (
+                    !req.query.compiler ||
+                    !manager.isCompilerActive(req.query.compiler)
+                ) {
+                    return res
+                        .status(400)
+                        .send(
+                            `Kevin couldn't find a compiler named ${req.query.compiler}.`
+                        );
+                }
+
+                manager
+                    .closeCompiler(req.query.compiler)
+                    .then((name) => {
+                        if (!name) {
+                            return res
+                                .status(400)
+                                .send(
+                                    `Kevin couldn't find a compiler named ${req.query.compiler}.`
+                                );
+                        }
+                        logInfo(`Stopped compiler: ${req.query.compiler}`);
+                        return res.sendStatus(200);
+                    })
+                    .catch((err) => {
+                        logError(err);
+                        res.status(500).send(
+                            `Something went wrong trying to stop ${req.query.compiler}. Check the logs for details.`
+                        );
+                    });
+
+                return;
+            }
+
             // Mangle the url to get asset name
             const assetName = this.getAssetName(reqPath, req, res);
             // Select appropriate config for given asset

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -476,6 +476,35 @@ class Kevin {
                 return;
             }
 
+            if (
+                req.method === "POST" &&
+                reqPath === `${this.kevinApiPrefix}/start-compiler`
+            ) {
+                // This endpoints starts a compiler. It accepts one query param:
+                // `compiler` (required), the name of the compiler to be started
+                if (
+                    !req.query.compiler ||
+                    manager.isCompilerActive(req.query.compiler)
+                ) {
+                    return res
+                        .status(400)
+                        .send(
+                            `Kevin couldn't find a inactive compiler named ${req.query.compiler}.`
+                        );
+                }
+
+                this.buildConfig(req.query.compiler)
+                    .then(() => res.sendStatus(200))
+                    .catch((err) => {
+                        logError(err);
+                        res.status(500).send(
+                            `Something went wrong trying to start ${req.query.compiler}. Check the logs for details.`
+                        );
+                    });
+
+                return;
+            }
+
             // Mangle the url to get asset name
             const assetName = this.getAssetName(reqPath, req, res);
             // Select appropriate config for given asset

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -453,6 +453,14 @@ class Kevin {
                         );
                 }
 
+                // Get the info for the compiler to be stopped...
+                const compilerToEvict = req.query.compiler;
+                const compilerStats = manager.getInfoForCompiler(compilerToEvict);
+
+                // Update the eviction decision
+                const options = { compilerToEvict, compilerStats };
+                this.hooks.compilerClose.call(options);
+
                 manager
                     .closeCompiler(req.query.compiler)
                     .then((name) => {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -491,6 +491,12 @@ class Kevin {
                         .send(
                             `Kevin couldn't find a inactive compiler named ${req.query.compiler}.`
                         );
+                } else if (manager.countActiveCompilers() >= this.maxCompilers) {
+                    return res
+                        .status(400)
+                        .send(
+                            `${req.query.compiler} can't be started because Kevin has reached the maximum of active compilers. Please stop one first.`
+                        );
                 }
 
                 this.buildConfig(req.query.compiler)


### PR DESCRIPTION
## Description

It adds two new endpoints: `/start-compiler` and `stop-compiler`. They can be used to manually start and stop a specific compiler.

## Context / Why are we making this change?

These endpoints will give users more control of the things they have compiled.

## Testing and QA Plan

1. Pull this branch: `abarraza_WEBPLAT-4421_start-and-stop-compiler-endpoints`
2. Use the local copy of Kevin middleware using [`yarnpkg link`](https://yarnpkg.com/cli/link)
3. Run your server.
4. Use the new endpoints to start and stop a compiler.

## Impact

This change adds new functionality to Kevin. It doesn't affect what existed before these commits.
