### PR TITLE
Add hasMaxActiveCompilersBeenReached to /compiler-info

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -368,7 +368,9 @@ class Kevin {
                     compilers[name] = { status: NOT_BUILT };
                 });
 
-                res.json({ compilers, leastUsedCompiler });
+                const areActiveCompilersAtMax = this.areActiveCompilersAtMax();
+
+                res.json({ compilers, leastUsedCompiler, areActiveCompilersAtMax });
                 return;
             }
 
@@ -376,13 +378,6 @@ class Kevin {
                 // this endpoint lists memory stats for the process in
                 // which kevin is being run
                 res.json(manager.getHumanReadableMemoryUsage());
-                return;
-            }
-
-            if (reqPath === `${this.kevinApiPrefix}/are-active-compilers-at-max`) {
-                // This endpoint returns whether Kevin is at the maximum of
-                // active compilers or not.
-                res.json({ areActiveCompilersAtMax: this.areActiveCompilersAtMax() });
                 return;
             }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -382,7 +382,7 @@ class Kevin {
             if (reqPath === `${this.kevinApiPrefix}/are-active-compilers-at-max`) {
                 // This endpoint returns whether Kevin is at the maximum of
                 // active compilers or not.
-                res.json(this.areActiveCompilersAtMax());
+                res.json({ areActiveCompilersAtMax: this.areActiveCompilersAtMax() });
                 return;
             }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -368,9 +368,13 @@ class Kevin {
                     compilers[name] = { status: NOT_BUILT };
                 });
 
-                const areActiveCompilersAtMax = this.areActiveCompilersAtMax();
+                const hasMaxActiveCompilersBeenReached = this.hasMaxActiveCompilersBeenReached();
 
-                res.json({ compilers, leastUsedCompiler, areActiveCompilersAtMax });
+                res.json({
+                    compilers,
+                    leastUsedCompiler,
+                    hasMaxActiveCompilersBeenReached,
+                });
                 return;
             }
 
@@ -497,10 +501,10 @@ class Kevin {
         res.send(jsString);
     }
 
-    /** It determines whether Kevin is at the maximum of active compilers or not
+    /** It determines whether Kevin has reached the maximum of active compilers or not
      * @returns {Boolean} True if Kevin is at the maximum, false if not.
      */
-    areActiveCompilersAtMax() {
+    hasMaxActiveCompilersBeenReached() {
         const activeCompilerCount = manager.countActiveCompilers();
         if (activeCompilerCount === this.maxCompilers) {
             return true;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -379,6 +379,13 @@ class Kevin {
                 return;
             }
 
+            if (reqPath === `${this.kevinApiPrefix}/are-active-compilers-at-max`) {
+                // This endpoint returns whether Kevin is at the maximum of
+                // active compilers or not.
+                res.json(this.areActiveCompilersAtMax());
+                return;
+            }
+
             if (
                 req.method === "POST" &&
                 reqPath === `${this.kevinApiPrefix}/restart-compiler`
@@ -493,6 +500,17 @@ class Kevin {
     ${JSON.stringify(errMsg)}
     \`, 'font-weight: bold; font-size: 1.5em', '')`;
         res.send(jsString);
+    }
+
+    /** It determines whether Kevin is at the maximum of active compilers or not
+     * @returns {Boolean} True if Kevin is at the maximum, false if not.
+     */
+    areActiveCompilersAtMax() {
+        const activeCompilerCount = manager.countActiveCompilers();
+        if (activeCompilerCount === this.maxCompilers) {
+            return true;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
## Description

It creates a function to get if Kevin is at the maximum of active compilers. It returns `true` if that's the case, `false` if not, and it is used in `/compiler-info`

## Context / Why are we making this change?

This new info we send to `/compiler-info` will help to know if we are able to manually start a compiler.

## Testing and QA Plan

1. Pull this branch: `abarraza_WEBPLAT-4423_show-are-we-at-max-active-compilers`
2. Use the local copy of Kevin middleware using [yarnpkg link](https://yarnpkg.com/cli/link)
3. Run your server.
4. See how many active compilers you have and hit `/compiler-info`. Check if it returns what you expect: `true` if you have the maximum of active compilers and `false` if not.


## Questions and follow up

This PR accepts suggestions of better names of the function 🤣 , I'm not convinced with the name I gave to it.
